### PR TITLE
/about and /get-involved updates for 2023

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -50,8 +50,8 @@ function About({ teams }: Teams) {
             So if you’ve ever wanted to get your face on screen, try out your
             skills behind a camera, or have a brilliant idea for a show then
             email{" "}
-            <a href="mailto:getinvolved@ystv.co.uk">getinvolved@ystv.co.uk</a>{" "}
-            or click here to <Link href="/get-involved">get involved</Link>!
+            <a href="mailto:welcome@ystv.co.uk">welcome@ystv.co.uk</a>{" "}
+            or <Link href="/get-involved">find out more about getting involved</Link>!
           </p>
         </div>
         <br /> <h2>Our Teams:</h2>

--- a/pages/get-involved.tsx
+++ b/pages/get-involved.tsx
@@ -15,7 +15,6 @@ export default function GetInvolved() {
               maybe you always wanted to direct a live music show.&nbsp; If this
               sounds familiar, YSTV is the society for you.
             </p>
-            <p>&nbsp;</p>
             <p>
               You can have a go at anything and everything at YSTV.&nbsp; From
               producing to presenting, from writing to editing, from directing
@@ -25,178 +24,35 @@ export default function GetInvolved() {
             <p>
               To get involved in YSTV email us at{" "}
               <strong>
-                <a href="mailto:getinvolved@ystv.co.uk">
-                  getinvolved@ystv.co.uk
+                <a href="mailto:welcome@ystv.co.uk">
+                  welcome@ystv.co.uk
                 </a>
               </strong>
               , or drop in to our studio anytime.&nbsp; You can find out where
               we are by clicking <Link href="/find-us">here</Link>.
             </p>
-            <p>&nbsp;</p>
             <p>
-              If you like what you hear and want to know how to get started,{" "}
-              <strong>
-                <a href="https://welcome.ystv.co.uk/">
-                  take a look at our getting started guide
-                </a>
-              </strong>{" "}
-              and {/*<a href="https://auth.ystv.co.uk/signup">*/}
-              {/*  create an account on our website*/}
-              {/*</a>*/}
-              <a href="http://go.ystv.co.uk/signup">
-                sign up to our mailing list
-              </a>
-              !
-            </p>
-            <p>&nbsp;</p>
-            <p>
-              For more information about what you can do at YSTV, click on the
-              links to the left.
-            </p>
-            <p>&nbsp;</p>{" "}
-          </div>
-
-          <h2>Crewing Shows</h2>
-          <div>
-            <p>
-              Crewing shows involve a lot of people in various positions and
-              jobs. The following is a list of what we need and what they
-              entail, which anyone new could easily slide into doing:
-            </p>
-            <p>&nbsp;</p>
-            <p>
-              <strong>CAMERA OPERATOR</strong>
-              <br />
-              As the name suggests, camera ops operate the cameras. After being
-              trained how to use a camera, you can crew all of our shows as they
-              will always need camera ops! If you enjoy filming and getting good
-              shots, sometimes with a director in your ear, this job is for you.
+              We send out a regular{" "}
+              <a href="http://go.ystv.co.uk/signup2023">
+                newsletter
+              </a>{" "}
+              with updates on upcoming productions, so make sure you sign up (you’ll need to sign in with your University account).
             </p>
             <p>
-              <strong>DIRECTOR</strong>
-              <br />
-              The director leads the show, making sure everyone is doing
-              everything they need to be doing at the right time. They&apos;re
-              in charge of ensuring all members of the team do their job!
-            </p>
-            <p>
-              <strong>FLOOR MANAGER</strong>
-              <br />
-              Floor manager makes sure that everyone and everything is running
-              smoothly and gives support to the director.&nbsp;
-            </p>
-            <p>
-              <strong>GRAPHICS OPERATOR</strong>
-              <br />
-              The graphics that appear on screen are controlled by the graphics
-              op.&nbsp;
-            </p>
-            <p>
-              <strong>RUNNER</strong>
-              <br />
-              Runners do a lot of running around! Whatever the director or
-              anyone else wants, the runner does to ensure an effective and
-              smooth show.&nbsp;
-            </p>
-            <p>
-              <strong>SOUND OPERATOR</strong>
-              <br />
-              After being trained how to use the sound desk, the sound operator
-              ensures that sound during shows is running without a hitch.&nbsp;
-            </p>
-            <p>
-              <strong>VISION MIXER</strong>
-              <br />
-              Ever wondered who chooses between which camera shots get to be on
-              telly? That&apos;s the vision mixer&apos;s job. Although it looks
-              like you&apos;re merely pressing buttons, it&apos;s one of the
-              most popular jobs!&nbsp;
-            </p>
-            <p>
-              <strong>VT OPERATOR&nbsp;</strong>
-              <br />
-              VT stands for &apos;video tape&apos;, in other words pre-filmed
-              and edited footage made specifically for programmes. A VT operator
-              is needed to ensure that VTs appear on screen during live shows.
-            </p>
-            <p>
-              <strong>PRESENTING</strong>
-              <br />
-              Think you’ve got a face for television? Or always wanted to try
-              out your Paxman impression on camera? Whatever your presenting
-              ambition, we want to hear from you! We run presenting workshops,
-              and give one on one advice to wannabe presenters. Just get in
-              touch with our Production Director, who can advise you further.
-            </p>
-            <p>
-              <strong>PRODUCING</strong>
-              <br />
-              The Production Team is always on the lookout for new ideas and
-              budding producers. If you&apos;re interested in getting involved
-              with the creation and running of our programmes, we want you
-              working on our Team! New members wishing to become a permanent
-              part of the Production Team are always welcome. We are a flexible,
-              friendly and enthusiastic group of people passionate about TV
-              production, and if you have something to offer us, or want to find
-              out more about what we do, we would love to have you.
-              <br />
-              Despite the fanciness of the word &apos;production&apos;, it is in
-              essence another way of saying &apos;creating and organising a
-              show&apos;. Production involves a plethora of things to do and
-              skills to learn or build upon, and is without a doubt one of the
-              best and easiest ways to get involved at YSTV. If you love to
-              organise, delegate, lead, create and inspire, then production is
-              for you. From finding the concept for a new show, to bringing the
-              right people together to make it happen, to learning how to
-              operate a camera and edit footage, production is hands-on,
-              extremely fun, and open to anyone willing to put in the time. Even
-              if you don&apos;t have a specific idea for a show, talk to us!
-              There&apos;s something for everyone, and you will have the time of
-              your life!
-              <br />
-              To give you a taste of what we do, please do email us!
-            </p>
-            <p>
-              <strong>PUBLICITY</strong>
-              <br />
-              The Commercial Team controls the &apos;face of YSTV&apos; and is
-              responsible for promoting the station to campus and the outside
-              world.
-              <br />
-              We&apos;re an open, friendly team and are always looking for new
-              faces and talents. If you&apos;re interested in marketing,
-              branding, graphic design, photography, organising sponsorship or
-              masterminding an advertising campaign, then don&apos;t hesitate to
-              get in touch with our Commercial Director at&nbsp;
-              <strong>
-                <a href="mailto:commercial.director@ystv.co.uk">
-                  commercial.director@ystv.co.uk
-                </a>
-              </strong>
-              .
-            </p>
-            <p>
-              <strong>TECHNICAL</strong>
-              <br />
-              YSTV has some of the best techies in the country, and we’re always
-              on the lookout for more. With so much equipment to maintain, there
-              is always an opportunity for the more tech-minded to try out their
-              skills. Get in touch with our Technical Director or Computing
-              Officer for more information.
-            </p>
-
-            <p>&nbsp;</p>
-            <p>
-              Interested in learning more and getting involved? Email&nbsp;
-              <strong>
-                <a href="mailto:production.director@ystv.co.uk">
-                  production.director@ystv.co.uk
-                </a>
-              </strong>
-              . <span>No experience is necessary!</span>
-              &nbsp;We look forward to hearing from you!
+              On a day-to-day basis we talk to each other and plan productions using Slack (if you’ve used Discord it’s very similar).
+              You can <a href="http://go.ystv.co.uk/slack">join our Slack workspace</a> to talk to us.
             </p>
           </div>
+
+          <p>&nbsp;</p>
+          <p>
+            Interested in learning more and getting involved? Email&nbsp;
+            <strong>
+              <a href="mailto:welcome@ystv.co.uk">welcome@ystv.co.uk</a>
+            </strong>
+            . <span>No experience is necessary!</span>
+            &nbsp;We look forward to hearing from you!
+          </p>
         </>
       </main>
     </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,13 @@
       "./types/videojs",
       "./node_modules/@types"
     ],
-    "incremental": true
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": true
   },
   "exclude": [
     "node_modules"
@@ -29,6 +35,7 @@
   "include": [
     "next-env.d.ts",
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    ".next/types/**/*.ts"
   ]
 }


### PR DESCRIPTION
Key changes:
* Updated all emails to welcome[@]ystv.co.uk
* Removed the list of positions from /get-involved
* Added links to newsletter and Slack signup (left AdamRMS for now)
* Few tweaks to semantic links
* Removed links to welcome site (as this is effectively replacing it)